### PR TITLE
chore: upgrade Gemini model from preview to stable (gemini-3.1-flash-lite)

### DIFF
--- a/backend/app/model_config.yaml
+++ b/backend/app/model_config.yaml
@@ -11,15 +11,15 @@ cache:
 features:
   market_pulse:
     provider: gemini
-    model: gemini-3.1-flash-lite-preview
+    model: gemini-3.1-flash-lite
     max_tokens: 1024
 
   ticker_brief:
     provider: gemini
-    model: gemini-3.1-flash-lite-preview
+    model: gemini-3.1-flash-lite
     max_tokens: 1024
 
 defaults:
   provider: gemini
-  model: gemini-3.1-flash-lite-preview
+  model: gemini-3.1-flash-lite
   max_tokens: 1024


### PR DESCRIPTION
## Summary

`model_config.yaml`의 모든 기능에서 Gemini 모델을 preview 버전에서 stable 버전으로 변경합니다.

- `gemini-3.1-flash-lite-preview` → `gemini-3.1-flash-lite`

## Changes

- `backend/app/model_config.yaml`: `market_pulse`, `ticker_brief`, `defaults` 모두 stable 모델로 변경

## Test plan

- [x] `market_pulse` API 정상 응답 확인
- [x] `ticker_brief` API 정상 응답 확인

Closes #12