### PR TITLE
fix: Market Pulse 탭 활성화 상태에서 홈 네비게이션 버그 수정

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,30 +1,30 @@
 "use client";
 
-/**
- * app/page.tsx
- * ─────────────
- * 홈 페이지: fin-aily 브랜드 및 탭 인터페이스 (Ticker Brief / Market Pulse).
- */
-
-import { useState, useEffect } from "react";
+import { useState, useEffect, Suspense } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import { TickerSearch } from "@/components/ui/TickerSearch";
 import { DigestCard } from "@/components/news/DigestCard";
 import { api, type NewsResponse } from "@/lib/api";
 
 type TabType = "brief" | "pulse";
 
-export default function HomePage() {
-  const [activeTab, setActiveTab] = useState<TabType>("brief");
+function HomeContent() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const activeTab: TabType = searchParams.get("tab") === "pulse" ? "pulse" : "brief";
+
   const [marketData, setMarketData] = useState<NewsResponse | null>(null);
   const [loading, setLoading] = useState(false);
 
-  // Market Pulse 데이터 로드
+  const setActiveTab = (tab: TabType) => {
+    router.push(tab === "pulse" ? "/?tab=pulse" : "/");
+  };
+
   useEffect(() => {
     if (activeTab === "pulse" && !marketData) {
       const loadMarketPulse = async () => {
         setLoading(true);
         try {
-          // 백엔드 엔드포인트: GET /news/market-pulse
           const data = await api.news.getMarketPulse();
           setMarketData(data);
         } catch (error) {
@@ -44,8 +44,8 @@ export default function HomePage() {
         <div className="text-4xl sm:text-5xl mb-4">📈</div>
         <h1 className="text-3xl sm:text-4xl font-extrabold text-slate-900 tracking-tight">fin-Aily</h1>
         <p className="text-slate-500 text-sm sm:text-base max-w-md mx-auto leading-relaxed">
-          {activeTab === "brief" 
-            ? "티커를 검색하면 AI가 최신 뉴스를 10개의 핵심 포인트로 요약해드립니다." 
+          {activeTab === "brief"
+            ? "티커를 검색하면 AI가 최신 뉴스를 10개의 핵심 포인트로 요약해드립니다."
             : "최신 주요 경제 소식을 AI 비서가 정리해드립니다."}
         </p>
       </div>
@@ -55,8 +55,8 @@ export default function HomePage() {
         <button
           onClick={() => setActiveTab("brief")}
           className={`flex-1 py-2.5 text-sm font-bold rounded-xl transition-all ${
-            activeTab === "brief" 
-              ? "bg-white text-blue-600 shadow-md" 
+            activeTab === "brief"
+              ? "bg-white text-blue-600 shadow-md"
               : "text-slate-500 hover:text-slate-800"
           }`}
         >
@@ -65,8 +65,8 @@ export default function HomePage() {
         <button
           onClick={() => setActiveTab("pulse")}
           className={`flex-1 py-2.5 text-sm font-bold rounded-xl transition-all ${
-            activeTab === "pulse" 
-              ? "bg-white text-blue-600 shadow-md" 
+            activeTab === "pulse"
+              ? "bg-white text-blue-600 shadow-md"
               : "text-slate-500 hover:text-slate-800"
           }`}
         >
@@ -101,5 +101,13 @@ export default function HomePage() {
         )}
       </div>
     </div>
+  );
+}
+
+export default function HomePage() {
+  return (
+    <Suspense>
+      <HomeContent />
+    </Suspense>
   );
 }


### PR DESCRIPTION
## Summary

Closes #14

- Market Pulse 탭 활성화 상태에서 헤더의 홈/fin-Aily 링크 클릭 시 메인으로 돌아가지 않던 버그 수정
- 탭 상태 관리 방식을 `useState` → URL 쿼리 파라미터(`?tab=pulse`)로 변경
- `useSearchParams` 사용에 따른 `Suspense` 경계 추가 (`HomeContent` 컴포넌트 분리)

## Root Cause

홈 링크(`/`)를 클릭할 때 이미 `/` 페이지에 있으므로 Next.js가 페이지 이동을 수행하지 않아 `useState` 탭 상태가 리셋되지 않았다.

## Changes

- `frontend/app/page.tsx`
  - `useState<TabType>` 제거, `useSearchParams`로 URL에서 탭 상태 읽도록 변경
  - 탭 전환 시 `router.push('/')` / `router.push('/?tab=pulse')` 사용
  - `useSearchParams` 요구사항에 맞게 `Suspense`로 `HomeContent` 래핑

## Test plan

- [x] Market Pulse 탭 클릭 후 헤더 홈 링크 클릭 → Ticker Brief 탭으로 복귀 확인
- [x] Market Pulse 탭 클릭 후 fin-Aily 로고 클릭 → Ticker Brief 탭으로 복귀 확인
- [x] Ticker Brief 탭에서 홈 링크 클릭 → 정상 동작 확인
- [x] Market Pulse 데이터 로드 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)