### PR TITLE
fix: 모바일에서 Market Pulse 뉴스 텍스트 오버플로우 버그 수정

### DIFF
--- a/frontend/components/news/ArticleList.tsx
+++ b/frontend/components/news/ArticleList.tsx
@@ -51,7 +51,7 @@ export function ArticleList({ articles, symbol }: Props) {
                 href={article.url}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="group block flex-1"
+                className="group block flex-1 min-w-0"
               >
                 <p className="text-sm font-medium text-slate-800 group-hover:text-blue-600 transition-colors line-clamp-2 leading-snug">
                   {article.title}
@@ -60,7 +60,7 @@ export function ArticleList({ articles, symbol }: Props) {
                 <ArticleMeta source={article.source} publishedAt={article.published_at} />
               </a>
             ) : (
-              <div className="flex-1">
+              <div className="flex-1 min-w-0">
                 <p className="text-sm font-medium text-slate-800 line-clamp-2 leading-snug">
                   {article.title}
                 </p>

--- a/frontend/components/news/DigestCard.tsx
+++ b/frontend/components/news/DigestCard.tsx
@@ -54,7 +54,7 @@ export function DigestCard({ digest, symbol, articles }: Props) {
             ) : (
               <span className="mt-0.5 text-slate-400 shrink-0 select-none">•</span>
             )}
-            <div className="flex flex-col gap-1">
+            <div className="flex flex-col gap-1 min-w-0">
               <span>{bullet.point}</span>
               {symbol === "MARKET" && articles?.[i] ? (
                 <a


### PR DESCRIPTION
## Summary

- Flexbox 레이아웃에서 `min-width: auto` 기본값으로 인해 `truncate`, `line-clamp-2`가 동작하지 않아 모바일에서 뉴스 텍스트가 컨테이너 박스를 벗어나는 현상 수정
- `DigestCard.tsx`, `ArticleList.tsx`의 flex 자식 요소에 `min-w-0` 추가

## Changes

- `frontend/components/news/DigestCard.tsx` — 요약 bullet의 텍스트/링크 감싸는 div에 `min-w-0` 추가
- `frontend/components/news/ArticleList.tsx` — URL 있는 기사(`<a>`)와 없는 기사(`<div>`) flex 자식에 `min-w-0` 추가

## Test plan

- [x] Chrome DevTools 모바일 뷰 (iPhone SE, Galaxy S20 등)에서 Market Pulse 탭 확인
- [ ] 뉴스 요약 텍스트가 카드 박스 안에서 말줄임(truncate/line-clamp) 처리되는지 확인
- [x] 데스크탑 뷰에서 레이아웃 깨짐 없는지 확인

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)