### PR TITLE
chore: 서비스명 fin-aily → fin-aily-us 전면 변경

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,4 @@ Thumbs.db
 .env
 .env.local
 *.log
+.vercel

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -14,4 +14,4 @@ APP_ENV=development
 DEBUG=true
 CORS_ORIGINS=["http://localhost:3000"]
 # 프로덕션 예시 (Vercel 도메인 추가):
-# CORS_ORIGINS=["http://localhost:3000","https://fin-aily.vercel.app"]
+# CORS_ORIGINS=["http://localhost:3000","https://fin-aily-us.vercel.app"]

--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -2,4 +2,4 @@ NEXT_PUBLIC_SUPABASE_URL=https://xxxx.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=eyJ...
 NEXT_PUBLIC_API_URL=http://localhost:8000/v1
 # 프로덕션 예시 (Cloud Run URL):
-# NEXT_PUBLIC_API_URL=https://fin-aily-xxxxx-uc.a.run.app/v1
+# NEXT_PUBLIC_API_URL=https://fin-aily-us-96426296927.asia-northeast1.run.app/v1

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "stock-insight-frontend",
+  "name": "fin-aily-us-frontend",
   "version": "1.0.0",
   "private": true,
   "scripts": {


### PR DESCRIPTION
Closes #20

## Summary

- `package.json` name 필드: `stock-insight-frontend` → `fin-aily-us-frontend`
- `frontend/.env.local.example`: Cloud Run URL 주석을 실제 배포 URL로 업데이트
- `backend/.env.example`: CORS_ORIGINS 예시 도메인 → `fin-aily-us.vercel.app`
- `.gitignore`: `.vercel` 디렉터리 추가

## 인프라 변경 내역 (콘솔/CLI에서 완료)

| 항목 | 변경 전 | 변경 후 |
|---|---|---|
| Cloud Run 서비스 | `fin-aily` (삭제됨) | `fin-aily-us` (asia-northeast1) |
| Cloud Run URL | `fin-aily-96426296927.asia-northeast1.run.app` | `fin-aily-us-96426296927.asia-northeast1.run.app` |
| Vercel 프로젝트명 | `fin-aily` | `fin-aily-us` |
| Vercel 도메인 | `fin-aily.vercel.app` (제거됨) | `fin-aily-us.vercel.app` |
| Vercel `NEXT_PUBLIC_API_URL` | 구 Cloud Run URL | 신 Cloud Run URL |
| GitHub repo | `fin-Aily` | `fin-aily-us` |

## Test plan

- [x] `https://fin-aily-us.vercel.app` 접속 확인
- [x] 티커 검색 및 AI 요약 정상 동작 확인
- [x] `https://fin-aily-us-96426296927.asia-northeast1.run.app/v1/health` (또는 docs) 응답 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)