### PR TITLE
docs: README 현행화 (Cloud Run 재배포 완료 — Stage 3 마무리)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ AI 기술로 미국 주식 뉴스를 투자자 관점의 핵심 인사이트로 
 | | URL |
 |---|---|
 | Frontend | https://fin-aily-us.vercel.app |
-| Backend API | https://fin-aily-us-96426296927.asia-northeast1.run.app |
+| Backend API | https://fin-aily-us-437915204376.asia-northeast1.run.app |
 
 ---
 
@@ -23,8 +23,8 @@ AI 기술로 미국 주식 뉴스를 투자자 관점의 핵심 인사이트로 
 - Yahoo Finance RSS 기반으로 시장 전체 흐름 AI 요약
 - 별도 검색 없이 접속 즉시 현재 가장 뜨거운 경제 이슈 확인
 
-### Deep Research (심층 리서치)
-- 종목 페이지의 **심층 리서치** 탭(`/stock/{symbol}/research`)에서 SEC EDGAR 10-K/10-Q 공시 기반 애널리스트 수준 리포트 생성
+### Deep Lab (심층 리서치)
+- 홈의 **Deep Lab** 탭에서 티커 검색 → 리서치 페이지(`/stock/{symbol}/research`)로 진입, SEC EDGAR 10-K/10-Q 공시 기반 애널리스트 수준 리포트 생성
 - Map-Reduce LLM 파이프라인으로 대용량 공시를 섹션별 병렬 요약 후 단일 리포트로 합성 (목차·표·출처 포함)
 - 생성은 백그라운드 잡으로 진행되며 프론트가 5초 간격 폴링으로 진행 상태 표시 (약 2~4분)
 - 완료 리포트는 168시간 캐시. 현재 **개인 사용 모드**라 로그인 없이 누구나 조회·생성 가능 (인증·사용자별 한도는 추후 재도입 예정, 코드는 `backend/app/dependencies.py`의 `get_current_user`에 보존)
@@ -130,6 +130,8 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=eyJ...
 NEXT_PUBLIC_API_URL=http://localhost:8000/v1
 ```
 
+백엔드 연동은 `NEXT_PUBLIC_API_URL` 하나면 충분하다 (**`/v1` 경로 포함**). 브리핑·심층 리서치 모두 같은 백엔드를 사용하므로 별도의 리서치 API URL 변수는 필요 없다.
+
 ---
 
 ## API
@@ -141,11 +143,18 @@ NEXT_PUBLIC_API_URL=http://localhost:8000/v1
 | `GET` | `/v1/news/{symbol}` | 종목 최신 뉴스 수집 + AI 요약 |
 | `GET` | `/v1/news/market-pulse` | 시장 전체 뉴스 AI 요약 |
 | `GET` | `/v1/tickers/search?q={쿼리}` | 티커·종목명 자동완성 검색 (Rate Limit: 30회/분) |
-| `POST` | `/v1/research/{symbol}` | 심층 리서치 잡 시작 (캐시·진행 중 잡은 즉시 반환) |
+| `POST` | `/v1/research/{symbol}` | 심층 리서치 잡 시작 (캐시·진행 중 잡은 즉시 반환, `?force=true`로 강제 재생성) (Rate Limit: 5회/분/IP) |
 | `GET` | `/v1/research/{symbol}` | 최신 완료 리포트 조회 |
 | `GET` | `/v1/research/jobs/{job_id}` | 잡 상태·완료 리포트 폴링 |
 
 > 현재 개인 사용 모드로 `/v1/research/*`는 인증 없이 열려 있다. 인증 로직(`get_current_user`)은 `backend/app/dependencies.py`에 보존되어 있어 필요 시 각 라우터에 `Depends`로 다시 연결할 수 있다.
+
+---
+
+## 배포
+
+- **Frontend**: Vercel — main 브랜치 push 시 자동 배포. `NEXT_PUBLIC_API_URL`에 Cloud Run URL + `/v1` 설정 (값 변경 시 Redeploy 필요)
+- **Backend**: Google Cloud Run — `--no-cpu-throttling`(응답 반환 후에도 백그라운드 리서치 잡이 CPU를 계속 사용해야 함)과 `--min-instances 1`(유휴 시 인스턴스 회수로 실행 중인 잡이 중단되는 것 방지) 플래그가 필수다. 상세 절차는 `working/cloudrun.md` 참조
 
 ---
 


### PR DESCRIPTION
Closes #31

## 요약

#31의 배포 작업이 모두 완료되어, 마지막 남은 README 현행화를 반영한다.

## 배포 완료 내역 (코드 외 작업 — 2026-07-07)

- **신규 GCP 프로젝트 `fin-aily-us`(437915204376)로 이전 배포** — 구 프로젝트(`central-surf-455822-j7`)의 서비스는 검증 후 삭제
  - 새 URL: `https://fin-aily-us-437915204376.asia-northeast1.run.app`
  - `--no-cpu-throttling`, `--min-instances 1`, `--memory 1Gi` 적용
- **검증 통과**: `/health`, 티커 검색 무회귀, 리서치 생성→완료(20KB 리포트), rate limit 429, 폴링 없이 방치해도 잡 완주(CPU 설정 정상 동작 확인)
- **Vercel**: `NEXT_PUBLIC_API_URL`을 새 URL + `/v1`로 갱신·재배포, 배포된 번들에서 반영 확인
- 상세 절차·트러블슈팅은 `working/cloudrun.md`에 별도 현행화 예정 (`--set-env-vars` 전체 교체 동작, CORS JSON 쉼표 구분자 이슈 등)

## README 변경 내용

- Backend URL을 새 주소로 교체
- Deep Research → **Deep Lab** 개칭, 진입 경로를 실제 UI(홈 탭 → 티커 검색)로 수정 (#32 탭바 제거 반영)
- 리서치 POST에 `?force=true`·rate limit(5회/분/IP) 명시
- 프론트 env는 `NEXT_PUBLIC_API_URL` 하나면 충분함을 명시 (`/v1` 포함)
- **배포** 섹션 신설: Cloud Run 필수 플래그와 이유

## 참고 — 스모크 테스트 중 발견된 버그 (별도 이슈 필요)

존재하지 않는 티커(`ZZZZZZ`)로 리서치를 요청하면 `failed`가 아니라 `completed`로 끝나며 데이터 없는 리포트가 생성됨. 잡 생성 전 티커 유효성 검증 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)