### PR TITLE
fix: 존재하지 않는 티커로 리서치 요청 시 즉시 404 반환

### DIFF
--- a/backend/app/research_pipeline/edgar.py
+++ b/backend/app/research_pipeline/edgar.py
@@ -131,13 +131,21 @@ class SecClient:
             "company_tickers.json",
             ttl_seconds=86400,
         )
-        for value in payload.values():
-            if str(value.get("ticker", "")).upper() == ticker_upper:
-                return CompanyIdentity(
-                    ticker=ticker_upper,
-                    cik=int(value["cik_str"]),
-                    company_name=str(value.get("title") or ticker_upper),
-                )
+        candidates = [ticker_upper]
+        # SEC 표기(BRK-B)와 사용자 입력(BRK.B)이 다를 수 있어 클래스 주식 구분자를 상호 변환해 재시도한다.
+        if "." in ticker_upper:
+            candidates.append(ticker_upper.replace(".", "-"))
+        elif "-" in ticker_upper:
+            candidates.append(ticker_upper.replace("-", "."))
+
+        for candidate in candidates:
+            for value in payload.values():
+                if str(value.get("ticker", "")).upper() == candidate:
+                    return CompanyIdentity(
+                        ticker=ticker_upper,
+                        cik=int(value["cik_str"]),
+                        company_name=str(value.get("title") or ticker_upper),
+                    )
         raise ValueError(f"Unable to resolve CIK for ticker: {ticker_upper}")
 
     def submissions(self, cik: int) -> dict[str, Any]:

--- a/backend/app/research_pipeline/generate.py
+++ b/backend/app/research_pipeline/generate.py
@@ -70,6 +70,9 @@ class ResearchPipeline:
 
         sec = SecClient(self.config.edgar_user_agent, self.config.cache_dir / "sec")
         edgar = sec.collect_company_bundle(ticker)
+        if edgar.identity.cik is None:
+            raise ValueError(f"Ticker not found on SEC EDGAR: {ticker} ({'; '.join(edgar.errors)})")
+
         companyfacts = None
         if edgar.identity.cik is not None:
             try:

--- a/backend/app/routers/research_router.py
+++ b/backend/app/routers/research_router.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 import re
 from pathlib import Path
@@ -10,8 +11,9 @@ from pydantic import BaseModel, Field
 from supabase import AsyncClient, acreate_client
 
 from app.dependencies import get_db
+from app.research_pipeline.edgar import SecClient
 from app.research_pipeline.generate import GenerateOptions, ResearchPipeline
-from app.research_pipeline.research_config import load_config
+from app.research_pipeline.research_config import AppConfig, load_config
 from app.research_pipeline.utils import ensure_dir
 from app.services import research_cache_service
 
@@ -64,6 +66,7 @@ async def create_research_job(
 ) -> ResearchJobResponse:
     normalized = _normalize_symbol(symbol)
     config = load_config()
+    await _ensure_known_symbol(normalized, config)
     await research_cache_service.cleanup_stale_jobs(db, config.research_job_timeout_minutes)
 
     ticker = await research_cache_service.ensure_ticker(db, normalized)
@@ -179,6 +182,27 @@ async def run_research_job(job_id: int, ticker_id: int, symbol: str) -> None:
         logger.exception("Research job failed: job_id=%s symbol=%s", job_id, symbol)
         if db is not None:
             await research_cache_service.fail_job(db, job_id, str(exc))
+
+
+async def _ensure_known_symbol(symbol: str, config: AppConfig) -> None:
+    """SEC EDGAR 티커 맵에 존재하는 심볼인지 사전 확인한다.
+
+    SEC 조회 자체가 실패(네트워크 순단 등)하면 검증을 통과시켜 잡 생성을
+    막지 않는다 — 최종 방어는 ResearchPipeline.run()의 cik None 체크가 맡는다.
+    """
+    sec = SecClient(config.edgar_user_agent, config.cache_dir / "sec")
+    try:
+        await asyncio.to_thread(sec.resolve_ticker, symbol)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=404,
+            detail=ErrorBody(
+                code="UNKNOWN_SYMBOL",
+                message=f"SEC EDGAR에서 찾을 수 없는 심볼입니다: {symbol}",
+            ).model_dump(),
+        ) from exc
+    except Exception:
+        logger.warning("SEC ticker lookup failed for %s; allowing job creation", symbol, exc_info=True)
 
 
 def _normalize_symbol(symbol: str) -> str:


### PR DESCRIPTION
Closes #34

## 버그

존재하지 않는 티커(예: `ZZZZZZ`)로 `POST /v1/research/{symbol}`을 호출하면 `failed`가 아니라 `completed`로 끝나면서 데이터 없는 리포트가 생성·캐시됨. 원인은 SEC CIK 조회 실패(`ValueError`)가 `edgar.py`의 `collect_company_bundle`에서 빈 fallback 번들로 흡수되고, 파이프라인이 그 상태로 섹션 생성을 강행하기 때문 (상세 원인 분석은 `working/bug.md` 참조 — 이번 PR에는 포함하지 않음, `working/*.md`는 로컬 작업 노트로 관리).

## 수정 (2중 방어)

1. **`research_router.py`**: `POST /{symbol}` 시점에 SEC 티커 맵으로 사전 검증 → 미존재 심볼은 티커/잡 생성 전에 즉시 `404 UNKNOWN_SYMBOL` 반환. SEC 조회 자체가 실패(네트워크 순단 등)하면 검증을 통과시켜 서비스 가용성을 지킴 — 이 경우는 아래 2번이 최종 방어
2. **`generate.py`**: `ResearchPipeline.run()`에서 `cik is None`이면 `ValueError` raise → 기존 `run_research_job`의 `except → fail_job` 경로로 자연스럽게 `failed` 처리
3. **`edgar.py`**: `resolve_ticker`에 클래스 주식 표기(`BRK.B` ↔ `BRK-B`) 상호 변환 재시도 추가 — 사전 검증 도입으로 이 표기 차이가 새로운 오탐(false positive 404)이 되지 않도록

## 프론트엔드

변경 없음. 기존 에러 플로우가 그대로 동작함을 코드 추적으로 확인:
`/stock/{symbol}/research` 진입 → GET 404(`REPORT_NOT_FOUND`) → 자동 `handleGenerate()` → POST 404(`UNKNOWN_SYMBOL`) → `ApiError.message`(한국어)를 그대로 노출 + "다시 시도" 버튼.

## 검증

로컬(`uvicorn`, 프로덕션 Supabase 공유)에서 확인:
- `POST /v1/research/ZZZZZZ` → 즉시 `404 UNKNOWN_SYMBOL`, 새 tickers row 생성 안 됨
- `POST /v1/research/AAPL` → 정상 (캐시 히트, 기존 흐름 무회귀)
- `resolve_ticker("BRK.B")` / `resolve_ticker("BRK-B")` → 둘 다 CIK 1067983(Berkshire) 정상 해석

## 남은 작업 (이 PR 범위 밖)

- 머지 후 Cloud Run 재배포 필요 (`gcloud run deploy` — 기존 배포 가이드의 env 전체 명시 방식 그대로)
- 배포 후 프로덕션 재검증: `POST /v1/research/ZZZZZZ` → 404 확인
- 이전 스모크 테스트가 남긴 Supabase 쓰레기 데이터 정리 (`ZZZZZZ`, `TEST1`~`TEST6`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)