### PR TITLE
fix: news_service url 참조 순서 오류 및 Market Pulse 네이밍 통일 (#37)

### DIFF
--- a/backend/app/routers/news_router.py
+++ b/backend/app/routers/news_router.py
@@ -3,7 +3,7 @@ news_router.py
 ──────────────
 뉴스 조회 라우터.
 - /news/{symbol}: 특정 종목 뉴스 및 요약
-- /news/market-pulse: MarketWatch 전체 시장 뉴스 및 요약
+- /news/market-pulse: Yahoo Finance 전체 시장 뉴스 및 요약
 """
 
 import logging
@@ -133,17 +133,17 @@ async def _get_or_summarize(
 @router.get(
     "/market-pulse",
     response_model=NewsResponse,
-    summary="MarketWatch 최신 뉴스 + AI 비서 요약",
+    summary="Yahoo Finance 최신 뉴스 + AI 비서 요약",
 )
 async def get_market_pulse(
     lang: str = Query(default="ko", pattern="^(ko|en)$"),
     db=Depends(get_db),
 ):
     """
-    MarketWatch의 최신 뉴스 10개를 가져와 '똑똑한 비서' 페르소나로 요약한다.
+    Yahoo Finance의 최신 뉴스 10개를 가져와 '똑똑한 비서' 페르소나로 요약한다.
     1시간 이내에 수집된 기사가 있으면 DB 캐시를 재사용한다.
     """
-    ticker_id = await get_or_create_ticker(db, "MARKET", "MarketWatch Top Stories")
+    ticker_id = await get_or_create_ticker(db, "MARKET", "Yahoo Finance Top Stories")
 
     raw_articles = await _get_or_fetch_articles(
         db, ticker_id, lambda: fetch_market_news(limit=10), limit=10
@@ -156,7 +156,7 @@ async def get_market_pulse(
 
     try:
         digest_out = await _get_or_summarize(
-            db, ticker_id, "MARKET", "MarketWatch Top Stories", raw_articles, lang,
+            db, ticker_id, "MARKET", "Yahoo Finance Top Stories", raw_articles, lang,
             feature="market_pulse",
         )
     except Exception as exc:
@@ -168,7 +168,7 @@ async def get_market_pulse(
 
     return NewsResponse(
         symbol="MARKET",
-        company_name="MarketWatch",
+        company_name="Yahoo Finance",
         last_updated=datetime.now(timezone.utc).isoformat(),
         digest=digest_out,
         articles=_build_article_outs(raw_articles),

--- a/backend/app/services/news_service.py
+++ b/backend/app/services/news_service.py
@@ -2,8 +2,8 @@
 news_service.py
 ───────────────
 뉴스 수집 서비스.
-yfinance → RSS(MarketWatch) 순으로 수집을 시도하며, 
-시장 전체 뉴스를 위한 MarketWatch 전용 수집 기능을 제공한다.
+yfinance → RSS(Yahoo Finance) 순으로 수집을 시도하며,
+시장 전체 뉴스를 위한 Yahoo Finance RSS 수집 기능을 제공한다.
 """
 
 import logging
@@ -63,12 +63,9 @@ async def fetch_articles(symbol: str, limit: int = 10) -> list[RawArticle]:
     return articles[:limit]
 
 async def fetch_market_news(limit: int = 10) -> list[RawArticle]:
-    """
-    Yahoo Finance 또는 MarketWatch의 금융 시장 전용 RSS에서 최신 뉴스를 수집한다.
-    """
-    # 사용자가 제안한 대로 Yahoo Finance를 사용하거나 MarketWatch의 시장 전용 피드를 선택합니다.
-    url = RSS_FEEDS["Yahoo_Finance"] # 또는 RSS_FEEDS["MarketWatch_Market"]
-    
+    """Yahoo Finance 종합 금융 RSS에서 최신 시장 뉴스를 수집한다."""
+    url = RSS_FEEDS["Yahoo_Finance"]
+
     articles = []
     try:
         feed = feedparser.parse(url)
@@ -78,20 +75,16 @@ async def fetch_market_news(limit: int = 10) -> list[RawArticle]:
                 datetime(*pub[:6], tzinfo=timezone.utc)
                 if pub else datetime.now(timezone.utc)
             )
-            
-            # 소스 이름 동적 할당
-            source_name = "Yahoo Finance" if "yahoo" in url else "MarketWatch"
-            
             articles.append(RawArticle(
                 title=entry.get("title", ""),
                 url=entry.get("link", ""),
-                source=source_name,
+                source="Yahoo Finance",
                 published_at=pub_dt,
                 raw_content=entry.get("summary", "") or _scrape_body(entry.get("link", "")) or entry.get("title", ""),
             ))
     except Exception as e:
         logger.error(f"{url} RSS 수집 오류: {e}")
-    
+
     return articles
 
 def _parse_pub_time(item: dict, content: dict) -> Optional[datetime]:
@@ -137,8 +130,6 @@ async def _fetch_from_yfinance(symbol: str, limit: int) -> list[RawArticle]:
             title = item.get("title") or content.get("title", "")
             if not title:
                 continue
-            raw_text = content.get("body", "") or content.get("summary", "") or _scrape_body(url) or title
-            pub_dt = _parse_pub_time(item, content)
             # yfinance 0.2.48+: 원문 URL은 content.clickThroughUrl에 있음
             # 값이 None인 경우를 대비해 or {} 패턴 사용
             url = (
@@ -147,6 +138,8 @@ async def _fetch_from_yfinance(symbol: str, limit: int) -> list[RawArticle]:
                 or (content.get("canonicalUrl") or {}).get("url", "")
                 or item.get("url", "")
             )
+            raw_text = content.get("body", "") or content.get("summary", "") or _scrape_body(url) or title
+            pub_dt = _parse_pub_time(item, content)
             articles.append(RawArticle(
                 title=title,
                 url=url,

--- a/backend/app/services/summarization_service.py
+++ b/backend/app/services/summarization_service.py
@@ -80,11 +80,11 @@ def _build_prompt(
         trimmed = article.content[:MAX_CONTENT_CHARS]
         articles_block += f"[기사 {i}] 제목: {article.title}\n출처: {article.source}\n내용: {trimmed}\n\n"
 
-    # Market Pulse (MarketWatch) 전용 프롬프트 (사용자 요청 반영)
+    # Market Pulse (Yahoo Finance) 전용 프롬프트 (사용자 요청 반영)
     if symbol == "MARKET":
         return f"""너는 주식투자에 도움을 주는 똑똑한 비서야.
-아래 제공된 MarketWatch 페이지의 최신 {len(articles)}개의 뉴스를 각각 요약해줘.
-https://www.marketwatch.com
+아래 제공된 Yahoo Finance의 최신 {len(articles)}개의 뉴스를 각각 요약해줘.
+https://finance.yahoo.com
 
 ## 지시사항
 1. 각 기사마다 정확히 하나의 point로 요약하세요. 여러 문장이 필요하면 하나의 point 안에 모두 포함하세요.


### PR DESCRIPTION
Closes #37

## 변경 내용

### 1. `_fetch_from_yfinance`의 `url` 정의 전 참조 수정
`url` 할당 블록을 `raw_text` 계산보다 앞으로 이동. 기존에는 `content.body`/`content.summary`가 모두 비어 있으면 정의되지 않은 `url`을 `_scrape_body(url)`에서 참조해 NameError가 발생했고, 함수 전체 try/except에 삼켜져 RSS fallback으로 증상이 가려졌다.

### 2. Market Pulse 네이밍 Yahoo Finance로 통일
수집원은 Yahoo Finance RSS인데 MarketWatch 표기가 잔존하던 곳 정리:
- `news_router.py` — docstring, MARKET 티커 생성명, 응답 `company_name`
- `summarization_service.py` — MARKET 프롬프트 (LLM에 "MarketWatch 페이지"라고 지시하던 부분)
- `news_service.py` — 존재하지 않는 `MarketWatch_Market` 키 언급 및 `source_name` 동적 분기 제거

## 검증
- 3개 파일 syntax check 통과
- `grep -rn MarketWatch app` → 잔존 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)