### PR TITLE
refactor: backend 미사용 코드 제거 (인증 잔재 전면 제거 포함) (#38)

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,6 @@ npm run dev
 GEMINI_API_KEY=your-gemini-api-key
 
 SUPABASE_URL=https://xxxx.supabase.co
-SUPABASE_ANON_KEY=eyJ...
 SUPABASE_SERVICE_ROLE_KEY=eyJ...
 
 APP_ENV=development

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -3,7 +3,6 @@ GEMINI_API_KEY=GEMINI_API_KEY
 
 # ── Supabase ───────────────────────────────────────────────────────────────────
 SUPABASE_URL=https://xxxx.supabase.co
-SUPABASE_ANON_KEY=eyJ...
 SUPABASE_SERVICE_ROLE_KEY=eyJ...
 
 # ── App ────────────────────────────────────────────────────────────────────────

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -19,7 +19,6 @@ class Settings(BaseSettings):
 
     # Supabase
     supabase_url: str
-    supabase_anon_key: str
     supabase_service_role_key: str
 
     # App

--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -4,7 +4,6 @@ dependencies.py
 FastAPI Depends 주입용 의존성 함수 모음.
 """
 
-from fastapi import Depends, Header, HTTPException
 from supabase import AsyncClient, acreate_client
 
 from app.config import get_settings
@@ -20,30 +19,3 @@ async def get_db() -> AsyncClient:
         settings.supabase_service_role_key,
     )
     return client
-
-
-# ── 인증 (현재 미사용) ──────────────────────────────────────────────────────────
-# 개인 사용 모드로 전환하며 라우터에서 연결을 끊었다. 재도입 시 각 라우터 엔드포인트에
-# `user: dict = Depends(get_current_user)`를 다시 추가하면 된다.
-async def get_current_user(
-    authorization: str | None = Header(default=None),
-    db: AsyncClient = Depends(get_db),
-) -> dict:
-    """Validate ``Authorization: Bearer <supabase_access_token>``. Anonymous access is rejected."""
-    if not authorization or not authorization.lower().startswith("bearer "):
-        raise HTTPException(
-            status_code=401,
-            detail={"code": "UNAUTHORIZED", "message": "로그인이 필요합니다."},
-        )
-    token = authorization.split(" ", 1)[1].strip()
-    try:
-        result = await db.auth.get_user(token)
-        user = result.user
-    except Exception:
-        user = None
-    if user is None:
-        raise HTTPException(
-            status_code=401,
-            detail={"code": "INVALID_TOKEN", "message": "유효하지 않은 세션입니다."},
-        )
-    return {"id": user.id, "email": user.email}

--- a/backend/app/research_pipeline/factpack.py
+++ b/backend/app/research_pipeline/factpack.py
@@ -125,7 +125,6 @@ def build_factpack(edgar: EdgarBundle, financials: FinancialBundle) -> FactPack:
     return FactPack(
         markdown=markdown,
         tables={
-            "financial_table": financial_table,
             "qoe_metrics": qoe_table,
             "capital_allocation_table": capital_table,
             "consensus_table": consensus_table,

--- a/backend/app/research_pipeline/research_config.py
+++ b/backend/app/research_pipeline/research_config.py
@@ -67,9 +67,6 @@ class AppConfig:
     model_config: dict[str, Any]
     supabase_url: str | None
     supabase_service_role_key: str | None
-    app_env: str
-    debug: bool
-    cors_origins: list[str]
     research_report_ttl_hours: int
     research_job_timeout_minutes: int
     api_use_llm: bool
@@ -86,9 +83,6 @@ def load_config() -> AppConfig:
         model_config=load_model_config(),
         supabase_url=settings.supabase_url,
         supabase_service_role_key=settings.supabase_service_role_key,
-        app_env=settings.app_env,
-        debug=settings.debug,
-        cors_origins=settings.cors_origins,
         research_report_ttl_hours=settings.research_report_ttl_hours,
         research_job_timeout_minutes=settings.research_job_timeout_minutes,
         api_use_llm=settings.research_api_use_llm,

--- a/backend/app/research_pipeline/sections.py
+++ b/backend/app/research_pipeline/sections.py
@@ -14,7 +14,6 @@ class SectionSpec:
     number: int
     title_ko: str
     prompt_file: str
-    data_keys: list[str]
     wave: int
     response_schema: dict[str, Any]
     renderer: Renderer
@@ -425,22 +424,20 @@ QA_SCHEMA = obj(
 
 
 SECTION_SPECS: list[SectionSpec] = [
-    SectionSpec(1, "Executive Summary", "p01_executive_summary.txt", ["wave1_takeaways"], 2, S1, render_executive),
+    SectionSpec(1, "Executive Summary", "p01_executive_summary.txt", 2, S1, render_executive),
     SectionSpec(
         2,
         "Business Structure & Narrative Shift",
         "p02_business_structure.txt",
-        ["segment_table", "item1_summaries", "mdna_summaries"],
         1,
         S2,
         render_business_structure,
     ),
-    SectionSpec(3, "Financial Quality & Margin", "p03_financial_quality.txt", [], 1, S3, render_financial_quality),
+    SectionSpec(3, "Financial Quality & Margin", "p03_financial_quality.txt", 1, S3, render_financial_quality),
     SectionSpec(
         4,
         "Filing Delta & Quality of Earnings",
         "p04_filing_delta.txt",
-        ["risk_summaries", "qoe_metrics"],
         1,
         S4,
         render_filing_delta,
@@ -449,7 +446,6 @@ SECTION_SPECS: list[SectionSpec] = [
         5,
         "Competitive Landscape & Customer Concentration",
         "p05_competitive_landscape.txt",
-        ["peer_table", "competition_excerpts"],
         1,
         S5,
         render_competitive,
@@ -458,7 +454,6 @@ SECTION_SPECS: list[SectionSpec] = [
         6,
         "Capital Allocation",
         "p06_capital_allocation.txt",
-        ["capital_allocation_table", "debt_detail"],
         1,
         S6,
         render_capital_allocation,
@@ -467,7 +462,6 @@ SECTION_SPECS: list[SectionSpec] = [
         7,
         "Earnings Call & Guidance",
         "p07_earnings_guidance.txt",
-        ["earnings_releases", "guidance_vs_actual"],
         1,
         S7,
         render_guidance,
@@ -476,7 +470,6 @@ SECTION_SPECS: list[SectionSpec] = [
         8,
         "Analyst Consensus & Valuation",
         "p08_consensus_valuation.txt",
-        ["consensus_table", "estimate_table", "valuation_band_table", "peer_table"],
         1,
         S8,
         render_valuation,
@@ -485,7 +478,6 @@ SECTION_SPECS: list[SectionSpec] = [
         9,
         "Technical & Key Risks",
         "p09_technical_risks.txt",
-        ["technical_table"],
         1,
         S9,
         render_risks,
@@ -494,7 +486,6 @@ SECTION_SPECS: list[SectionSpec] = [
         10,
         "Variant Perception & Final Assessment",
         "p10_variant_final.txt",
-        ["wave1_takeaways"],
         2,
         S10,
         render_variant,

--- a/backend/app/routers/research_router.py
+++ b/backend/app/routers/research_router.py
@@ -84,7 +84,7 @@ async def create_research_job(
         return _job_response(active, normalized, cached=False, include_report=False)
 
     # 인증 미도입 상태: 일일 한도는 사용자 식별(requested_by)에 의존하므로 비활성화.
-    # 재도입 시 get_current_user Depends + count_jobs_today 검사를 여기에 복구.
+    # 재도입 절차는 이슈 #8 참조.
     job = await research_cache_service.create_job(db, ticker_id=ticker["id"])
     background_tasks.add_task(run_research_job, int(job["id"]), int(ticker["id"]), normalized)
     return _job_response(job, normalized, cached=False, include_report=False)

--- a/backend/app/services/cache_service.py
+++ b/backend/app/services/cache_service.py
@@ -73,12 +73,8 @@ async def save_digest_cache(
     db: AsyncClient,
     ticker_id: int,
     digest_ko: DigestResult,
-    digest_en: Optional[DigestResult] = None,
 ) -> None:
-    """
-    종합 요약 결과를 ticker_summaries에 저장한다.
-    한/영 요약을 단일 행에 저장하여 중복 캐시를 방지한다.
-    """
+    """종합 요약 결과를 ticker_summaries에 저장한다."""
     def to_json(points: list[SummaryPoint]) -> str:
         return json.dumps([p.model_dump() for p in points], ensure_ascii=False)
 
@@ -86,7 +82,7 @@ async def save_digest_cache(
         "ticker_id":       ticker_id,
         "article_ids":     digest_ko.article_ids,
         "summary_ko":      to_json(digest_ko.summary),
-        "summary_en":      to_json(digest_en.summary) if digest_en else None,
+        "summary_en":      None,
         "sentiment_score": float(digest_ko.sentiment_score),
         "sentiment_label": digest_ko.sentiment_label,
         "model_version":   digest_ko.model_version,
@@ -96,16 +92,3 @@ async def save_digest_cache(
 
     await db.table("ticker_summaries").insert(payload).execute()
     logger.info("캐시 저장: ticker_id=%d, count=%d", ticker_id, digest_ko.article_count)
-
-
-async def invalidate_cache(db: AsyncClient, ticker_id: int) -> int:
-    """특정 티커의 캐시를 전부 삭제한다. 수동 갱신/테스트용."""
-    res = (
-        await db.table("ticker_summaries")
-        .delete()
-        .eq("ticker_id", ticker_id)
-        .execute()
-    )
-    deleted = len(res.data) if res.data else 0
-    logger.info("캐시 무효화: ticker_id=%d, deleted=%d", ticker_id, deleted)
-    return deleted

--- a/backend/app/services/research_cache_service.py
+++ b/backend/app/services/research_cache_service.py
@@ -161,21 +161,6 @@ async def create_job(
     return res.data[0]
 
 
-async def count_jobs_today(db: AsyncClient, requested_by: str) -> int:
-    """Count jobs created by ``requested_by`` since UTC midnight (status agnostic)."""
-    start_of_day = utc_now().replace(hour=0, minute=0, second=0, microsecond=0)
-    res = (
-        await db.table("research_reports")
-        .select("id", count="exact")
-        .eq("requested_by", requested_by)
-        .gte("created_at", start_of_day.isoformat())
-        .execute()
-    )
-    if res.count is not None:
-        return res.count
-    return len(res.data or [])
-
-
 async def get_job(db: AsyncClient, job_id: int) -> dict[str, Any] | None:
     res = (
         await db.table("research_reports")


### PR DESCRIPTION
Closes #38

## 변경 내용

### 미사용 코드
- `cache_service.py` — `invalidate_cache()` 제거, `save_digest_cache()`의 항상 `None`이던 `digest_en` 파라미터 제거
- `config.py` — 백엔드 미사용 `supabase_anon_key` 필드 제거 (필수 필드였어서 불필요한 env 요구 발생 중이었음) → `.env.example`, `README.md`도 함께 정리
- `research_pipeline/research_config.py` — 파이프라인이 참조하지 않는 `AppConfig.app_env/debug/cors_origins` 제거
- `research_pipeline/sections.py` — 코드가 읽지 않는 `SectionSpec.data_keys` 필드 제거
- `research_pipeline/factpack.py` — `_build_base_context`가 사용하지 않는 `tables["financial_table"]` 엔트리 제거

### 인증 잔재 전면 제거
- `dependencies.py` — `get_current_user()` 제거
- `research_cache_service.py` — `count_jobs_today()` 제거
- `research_router.py` — "재도입 시 복구" 주석을 이슈 #8 참조로 교체

인증 재도입 절차는 [#8 코멘트](https://github.com/jonas-jun/fin-aily-us/issues/8#issuecomment-4904812729)에 전체 문서화되어 있습니다.

## 검증
- 수정 파일 전체 syntax check 통과
- 제거 대상 심볼(`get_current_user`, `count_jobs_today`, `invalidate_cache`, `supabase_anon_key`, `data_keys`) grep 재확인 — 잔여 참조 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)