### PR TITLE
refactor: backend 공통화 — LLM 클라이언트 통합·티커 서비스·헬퍼 통일 (#40)

### DIFF
--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -12,10 +12,18 @@ settings = get_settings()
 
 
 # ── Supabase 클라이언트 ────────────────────────────────────────────────────────
-async def get_db() -> AsyncClient:
-    """요청마다 Supabase AsyncClient 인스턴스를 생성하여 주입한다."""
-    client = await acreate_client(
+async def create_db_client() -> AsyncClient:
+    """Supabase AsyncClient 인스턴스를 새로 생성한다.
+
+    FastAPI Depends 경로는 get_db()를 쓰고, BackgroundTasks처럼 Depends를
+    쓸 수 없는 경로(예: research_router.run_research_job)는 이 함수를 직접 호출한다.
+    """
+    return await acreate_client(
         settings.supabase_url,
         settings.supabase_service_role_key,
     )
-    return client
+
+
+async def get_db() -> AsyncClient:
+    """요청마다 Supabase AsyncClient 인스턴스를 생성하여 주입한다."""
+    return await create_db_client()

--- a/backend/app/llm.py
+++ b/backend/app/llm.py
@@ -1,3 +1,10 @@
+"""
+llm.py
+──────
+Gemini 호출 공용 클라이언트. 뉴스 요약(summarization_service)과
+심층 리서치 파이프라인(research_pipeline)이 함께 사용한다.
+"""
+
 from __future__ import annotations
 
 import asyncio
@@ -11,7 +18,8 @@ class LLMUnavailable(RuntimeError):
     pass
 
 
-def _parse_json_text(text: str) -> dict[str, Any]:
+def parse_json_response(text: str) -> dict[str, Any]:
+    """```json 코드펜스를 벗기고 JSON으로 파싱한다. 실패 시 첫 {...} 블록으로 재시도한다."""
     clean = text.strip()
     if clean.startswith("```"):
         clean = re.sub(r"^```(?:json)?", "", clean).strip()
@@ -64,15 +72,15 @@ class GeminiClient:
             text = "".join(getattr(part, "text", "") for part in parts)
         if not text:
             raise RuntimeError("Gemini returned an empty response")
-        return _parse_json_text(text)
+        return parse_json_response(text)
 
     async def generate_text(
         self,
         *,
         model: str,
-        system_prompt: str,
+        system_prompt: str | None = None,
         user_prompt: str,
-        temperature: float,
+        temperature: float = 0.2,
     ) -> str:
         if not self.api_key:
             raise LLMUnavailable("GEMINI_API_KEY is not configured")
@@ -103,4 +111,3 @@ async def gather_limited(limit: int, *coros: Any) -> list[Any]:
             return await coro
 
     return await asyncio.gather(*(run(coro) for coro in coros))
-

--- a/backend/app/research_pipeline/financials.py
+++ b/backend/app/research_pipeline/financials.py
@@ -220,11 +220,7 @@ def _value(series: dict[str, dict[int, dict[str, Any]]], metric: str, year: int)
     return float(item["value"])
 
 
-def _usd_m(value: float | None) -> float | None:
-    return None if value is None else value / 1_000_000
-
-
-def _shares_m(value: float | None) -> float | None:
+def _to_millions(value: float | None) -> float | None:
     return None if value is None else value / 1_000_000
 
 
@@ -268,18 +264,18 @@ def _build_financial_rows(
         rows.append(
             {
                 "FY": f"FY{year}",
-                "Revenue": format_money_m(_usd_m(revenue)),
+                "Revenue": format_money_m(_to_millions(revenue)),
                 "YoY": format_pct(revenue_yoy),
                 "GPM": format_pct(_pct(gross_profit, revenue)),
                 "OPM": format_pct(_pct(operating_income, revenue)),
                 "NPM": format_pct(_pct(net_income, revenue)),
-                "FCF": format_money_m(_usd_m(fcf)),
+                "FCF": format_money_m(_to_millions(fcf)),
                 "FCF Margin": format_pct(_pct(fcf, revenue)),
                 "SBC / Revenue": format_pct(_pct(sbc, revenue)),
                 "R&D / Revenue": format_pct(_pct(rd, revenue)),
                 "Capex / Revenue": format_pct(_pct(capex, revenue)),
                 "ROIC": format_pct(roic),
-                "Shares": format_number(_shares_m(shares), 1),
+                "Shares": format_number(_to_millions(shares), 1),
             }
         )
 
@@ -350,13 +346,13 @@ def _build_qoe_rows(series: dict[str, dict[int, dict[str, Any]]], years: list[in
                 "FY": f"FY{year}",
                 "Accrual Ratio": format_pct(_pct(None if net_income is None or cfo is None else net_income - cfo, avg_assets)),
                 "FCF / Net Income": format_pct(_pct(fcf, net_income)),
-                "Working Capital": format_money_m(_usd_m(working_capital)),
-                "SBC": format_money_m(_usd_m(_value(series, "sbc", year))),
-                "D&A": format_money_m(_usd_m(_value(series, "dna", year))),
-                "Deferred Tax": format_money_m(_usd_m(_value(series, "deferred_tax", year))),
-                "ΔAR": format_money_m(_usd_m(_value(series, "ar_change", year))),
-                "ΔInventory": format_money_m(_usd_m(_value(series, "inventory_change", year))),
-                "ΔAP": format_money_m(_usd_m(_value(series, "ap_change", year))),
+                "Working Capital": format_money_m(_to_millions(working_capital)),
+                "SBC": format_money_m(_to_millions(_value(series, "sbc", year))),
+                "D&A": format_money_m(_to_millions(_value(series, "dna", year))),
+                "Deferred Tax": format_money_m(_to_millions(_value(series, "deferred_tax", year))),
+                "ΔAR": format_money_m(_to_millions(_value(series, "ar_change", year))),
+                "ΔInventory": format_money_m(_to_millions(_value(series, "inventory_change", year))),
+                "ΔAP": format_money_m(_to_millions(_value(series, "ap_change", year))),
             }
         )
     return rows
@@ -368,12 +364,12 @@ def _build_capital_rows(series: dict[str, dict[int, dict[str, Any]]], years: lis
         rows.append(
             {
                 "FY": f"FY{year}",
-                "Buybacks": format_money_m(_usd_m(_value(series, "buybacks", year))),
-                "Dividends": format_money_m(_usd_m(_value(series, "dividends", year))),
-                "Acquisitions": format_money_m(_usd_m(_value(series, "acquisitions", year))),
-                "Debt Issued": format_money_m(_usd_m(_value(series, "debt_issued", year))),
-                "Debt Repaid": format_money_m(_usd_m(_value(series, "debt_repaid", year))),
-                "Shares": format_number(_shares_m(_value(series, "shares", year)), 1),
+                "Buybacks": format_money_m(_to_millions(_value(series, "buybacks", year))),
+                "Dividends": format_money_m(_to_millions(_value(series, "dividends", year))),
+                "Acquisitions": format_money_m(_to_millions(_value(series, "acquisitions", year))),
+                "Debt Issued": format_money_m(_to_millions(_value(series, "debt_issued", year))),
+                "Debt Repaid": format_money_m(_to_millions(_value(series, "debt_repaid", year))),
+                "Shares": format_number(_to_millions(_value(series, "shares", year)), 1),
             }
         )
     return rows

--- a/backend/app/research_pipeline/generate.py
+++ b/backend/app/research_pipeline/generate.py
@@ -5,12 +5,14 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from app.llm import GeminiClient, gather_limited
+from app.time_utils import utc_now_iso
+
 from .research_config import PROMPTS_DIR, AppConfig, load_config
 from .assemble import assemble_report
 from .edgar import EdgarBundle, FilingRecord, SecClient, fiscal_label
 from .factpack import FactPack, build_factpack
 from .financials import build_financial_bundle
-from .llm import GeminiClient, gather_limited
 from .sections import (
     QA_SCHEMA,
     SECTION_SPECS,
@@ -38,7 +40,6 @@ from .utils import (
     render_template,
     simple_summary,
     trim_text,
-    utc_now_iso,
     write_json,
 )
 

--- a/backend/app/research_pipeline/utils.py
+++ b/backend/app/research_pipeline/utils.py
@@ -3,13 +3,9 @@ from __future__ import annotations
 import json
 import re
 from dataclasses import asdict, is_dataclass
-from datetime import date, datetime, timezone
+from datetime import date, datetime
 from pathlib import Path
 from typing import Any, Iterable
-
-
-def utc_now_iso() -> str:
-    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
 
 
 def ensure_dir(path: Path) -> Path:

--- a/backend/app/routers/news_router.py
+++ b/backend/app/routers/news_router.py
@@ -7,7 +7,7 @@ news_router.py
 """
 
 import logging
-from datetime import datetime, timezone
+from datetime import datetime
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 
@@ -19,7 +19,7 @@ from app.services.article_cache_service import (
     save_articles,
 )
 from app.services.cache_service import get_cached_digest, save_digest_cache
-from app.services.news_service import RawArticle, fetch_articles, fetch_market_news, get_company_name
+from app.services.news_service import RawArticle, fetch_articles, fetch_market_news
 from app.services.summarization_service import (
     ArticleInput,
     ArticleOut,
@@ -28,6 +28,8 @@ from app.services.summarization_service import (
     SentimentOut,
     summarize_articles,
 )
+from app.services.ticker_service import ensure_ticker
+from app.time_utils import utc_now_iso
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/news", tags=["news"])
@@ -169,7 +171,7 @@ async def get_market_pulse(
     return NewsResponse(
         symbol="MARKET",
         company_name="Yahoo Finance",
-        last_updated=datetime.now(timezone.utc).isoformat(),
+        last_updated=utc_now_iso(),
         digest=digest_out,
         articles=_build_article_outs(raw_articles),
     )
@@ -191,8 +193,8 @@ async def get_news(
     1시간 이내에 수집된 기사가 있으면 DB 캐시를 재사용한다.
     """
     upper_symbol = symbol.upper()
-    company = get_company_name(upper_symbol)
-    ticker_id = await get_or_create_ticker(db, upper_symbol, company)
+    ticker = await ensure_ticker(db, upper_symbol)
+    ticker_id, company = ticker["id"], ticker["name"]
 
     raw_articles = await _get_or_fetch_articles(
         db, ticker_id, lambda: fetch_articles(upper_symbol, limit), limit=limit
@@ -217,7 +219,7 @@ async def get_news(
     return NewsResponse(
         symbol=upper_symbol,
         company_name=company,
-        last_updated=datetime.now(timezone.utc).isoformat(),
+        last_updated=utc_now_iso(),
         digest=digest_out,
         articles=_build_article_outs(raw_articles),
     )

--- a/backend/app/routers/research_router.py
+++ b/backend/app/routers/research_router.py
@@ -8,14 +8,14 @@ from typing import Any
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
 from pydantic import BaseModel, Field
-from supabase import AsyncClient, acreate_client
+from supabase import AsyncClient
 
-from app.dependencies import get_db
+from app.dependencies import create_db_client, get_db
 from app.research_pipeline.edgar import SecClient
 from app.research_pipeline.generate import GenerateOptions, ResearchPipeline
 from app.research_pipeline.research_config import AppConfig, load_config
 from app.research_pipeline.utils import ensure_dir
-from app.services import research_cache_service
+from app.services import research_cache_service, ticker_service
 
 
 logger = logging.getLogger(__name__)
@@ -69,7 +69,7 @@ async def create_research_job(
     await _ensure_known_symbol(normalized, config)
     await research_cache_service.cleanup_stale_jobs(db, config.research_job_timeout_minutes)
 
-    ticker = await research_cache_service.ensure_ticker(db, normalized)
+    ticker = await ticker_service.ensure_ticker(db, normalized)
     if not force:
         cached = await research_cache_service.get_cached_report(
             db,
@@ -101,7 +101,7 @@ async def get_latest_report(
 ) -> LatestReportResponse:
     normalized = _normalize_symbol(symbol)
     config = load_config()
-    ticker = await research_cache_service.ensure_ticker(db, normalized)
+    ticker = await ticker_service.ensure_ticker(db, normalized)
     row = await research_cache_service.get_cached_report(
         db,
         ticker_id=ticker["id"],
@@ -152,7 +152,7 @@ async def run_research_job(job_id: int, ticker_id: int, symbol: str) -> None:
     try:
         if not config.supabase_url or not config.supabase_service_role_key:
             raise RuntimeError("Supabase settings are not configured")
-        db = await acreate_client(config.supabase_url, config.supabase_service_role_key)
+        db = await create_db_client()
         await research_cache_service.mark_job_running(db, job_id, "리포트 생성 중")
 
         api_output_dir = ensure_dir(config.output_dir / "api")

--- a/backend/app/services/article_cache_service.py
+++ b/backend/app/services/article_cache_service.py
@@ -3,17 +3,19 @@ article_cache_service.py
 ────────────────────────
 뉴스 기사 DB 캐싱 서비스.
 - 1시간 TTL로 기사를 캐싱하여 외부 API 중복 호출을 방지한다.
-- ticker 조회/생성 헬퍼를 제공한다.
+- ticker 조회/생성 헬퍼를 제공한다 (실제 종목은 app.services.ticker_service를
+  사용하고, get_or_create_ticker는 "MARKET" 같은 의사 티커 전용).
 """
 
 import logging
-from datetime import datetime, timedelta, timezone
+from datetime import timedelta
 from typing import Optional
 
 from supabase import AsyncClient
 
 from app.config import get_cache_config
 from app.services.news_service import RawArticle
+from app.time_utils import utc_now
 
 logger = logging.getLogger(__name__)
 
@@ -49,7 +51,7 @@ async def get_cached_articles(
     limit: int = 10,
 ) -> Optional[list[dict]]:
 
-    cutoff = datetime.now(tz=timezone.utc) - timedelta(hours=get_cache_config().article_ttl_hours)
+    cutoff = utc_now() - timedelta(hours=get_cache_config().article_ttl_hours)
 
     res = (
         await db.table("news_articles")

--- a/backend/app/services/cache_service.py
+++ b/backend/app/services/cache_service.py
@@ -7,13 +7,14 @@ cache_service.py
 
 import json
 import logging
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from typing import Optional
 
 from supabase import AsyncClient
 
 from app.config import get_cache_config
 from app.services.summarization_service import DigestResult, SummaryPoint
+from app.time_utils import utc_now
 
 logger = logging.getLogger(__name__)
 
@@ -26,7 +27,7 @@ async def get_cached_digest(
     """
     유효한 캐시(TTL 이내)가 있으면 DigestResult를 반환하고, 없으면 None을 반환한다.
     """
-    cutoff = datetime.now(tz=timezone.utc) - timedelta(hours=get_cache_config().summary_ttl_hours)
+    cutoff = utc_now() - timedelta(hours=get_cache_config().summary_ttl_hours)
 
     res = (
         await db.table("ticker_summaries")

--- a/backend/app/services/news_service.py
+++ b/backend/app/services/news_service.py
@@ -15,6 +15,8 @@ import feedparser
 import yfinance as yf
 from newspaper import Article
 
+from app.time_utils import utc_now
+
 logger = logging.getLogger(__name__)
 
 RSS_FEEDS = {
@@ -43,15 +45,6 @@ def _scrape_body(url: str) -> str:
         return ""
 
 
-def get_company_name(symbol: str) -> str:
-    """yfinance에서 종목의 회사명을 조회한다. 실패 시 심볼 반환."""
-    try:
-        info = yf.Ticker(symbol).info
-        return info.get("longName") or info.get("shortName") or symbol
-    except Exception:
-        return symbol
-
-
 async def fetch_articles(symbol: str, limit: int = 10) -> list[RawArticle]:
     """티커 심볼에 대한 최신 뉴스를 수집한다."""
     articles = await _fetch_from_yfinance(symbol, limit)
@@ -73,7 +66,7 @@ async def fetch_market_news(limit: int = 10) -> list[RawArticle]:
             pub = entry.get("published_parsed")
             pub_dt = (
                 datetime(*pub[:6], tzinfo=timezone.utc)
-                if pub else datetime.now(timezone.utc)
+                if pub else utc_now()
             )
             articles.append(RawArticle(
                 title=entry.get("title", ""),

--- a/backend/app/services/research_cache_service.py
+++ b/backend/app/services/research_cache_service.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
-import asyncio
 import json
 import logging
-from datetime import datetime, timedelta, timezone
+from datetime import timedelta
 from pathlib import Path
 from typing import Any
 
@@ -11,67 +10,12 @@ from supabase import AsyncClient
 
 from app.research_pipeline.research_config import AppConfig
 from app.research_pipeline.utils import read_json
+from app.time_utils import utc_now
 
 logger = logging.getLogger(__name__)
 
 
 ACTIVE_STATUSES = ["pending", "running"]
-
-
-def utc_now() -> datetime:
-    return datetime.now(tz=timezone.utc).replace(microsecond=0)
-
-
-async def ensure_ticker(db: AsyncClient, symbol: str) -> dict[str, Any]:
-    normalized = symbol.upper().strip()
-    existing = (
-        await db.table("tickers")
-        .select("*")
-        .eq("symbol", normalized)
-        .limit(1)
-        .execute()
-    )
-    if existing.data:
-        return existing.data[0]
-
-    profile = await asyncio.to_thread(_lookup_ticker_profile, normalized)
-    payload = {
-        "symbol": normalized,
-        "name": profile.get("name") or normalized,
-        "exchange": profile.get("exchange"),
-        "sector": profile.get("sector"),
-    }
-    try:
-        inserted = await db.table("tickers").insert(payload).execute()
-        if inserted.data:
-            return inserted.data[0]
-    except Exception:
-        logger.info("Ticker insert raced or failed; retrying select: %s", normalized)
-
-    retry = (
-        await db.table("tickers")
-        .select("*")
-        .eq("symbol", normalized)
-        .limit(1)
-        .execute()
-    )
-    if retry.data:
-        return retry.data[0]
-    raise RuntimeError(f"Unable to create ticker row for {normalized}")
-
-
-def _lookup_ticker_profile(symbol: str) -> dict[str, Any]:
-    try:
-        import yfinance as yf  # type: ignore
-
-        info = yf.Ticker(symbol).info or {}
-        return {
-            "name": info.get("longName") or info.get("shortName"),
-            "exchange": info.get("exchange"),
-            "sector": info.get("sector"),
-        }
-    except Exception:
-        return {"name": symbol, "exchange": None, "sector": None}
 
 
 async def cleanup_stale_jobs(db: AsyncClient, timeout_minutes: int) -> None:

--- a/backend/app/services/summarization_service.py
+++ b/backend/app/services/summarization_service.py
@@ -5,15 +5,15 @@ summarization_service.py
 사용자 커스텀 프롬프트를 반영하여 시장 뉴스를 요약한다.
 """
 
-import json
 import logging
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Optional
 
-from google import genai
 from pydantic import BaseModel
 
 from app.config import get_feature_config
+from app.llm import GeminiClient, parse_json_response
+from app.time_utils import utc_now
 
 logger = logging.getLogger(__name__)
 
@@ -125,17 +125,6 @@ https://finance.yahoo.com
 ## 뉴스 데이터
 {articles_block}"""
 
-def _parse_llm_response(raw_text: str) -> dict:
-    raw_text = raw_text.strip()
-    if "```json" in raw_text:
-        raw_text = raw_text.split("```json")[1].split("```")[0]
-    elif "```" in raw_text:
-        raw_text = raw_text.split("```")[1].split("```")[0]
-    try:
-        return json.loads(raw_text)
-    except json.JSONDecodeError:
-        raise ValueError("LLM 응답 파싱 실패")
-
 async def summarize_articles(
     symbol: str,
     company_name: str,
@@ -150,14 +139,14 @@ async def summarize_articles(
     feat_config = get_feature_config(feature)
     prompt = _build_prompt(symbol, company_name, articles[:MAX_ARTICLES], lang)
 
-    client = genai.Client(api_key=api_key)
-    response = await client.aio.models.generate_content(
-        model=feat_config.model,
-        contents=prompt,
-    )
-    raw_text, model_version = response.text, feat_config.model
+    client = GeminiClient(api_key=api_key)
+    raw_text = await client.generate_text(model=feat_config.model, user_prompt=prompt)
+    model_version = feat_config.model
 
-    parsed = _parse_llm_response(raw_text)
+    try:
+        parsed = parse_json_response(raw_text)
+    except Exception:
+        raise ValueError("LLM 응답 파싱 실패")
     bullets = [SummaryPoint(**b) for b in parsed.get("summary", [])]
 
     return DigestResult(
@@ -167,5 +156,5 @@ async def summarize_articles(
         model_version=model_version,
         article_ids=[a.id for a in articles[:MAX_ARTICLES]],
         article_count=len(articles[:MAX_ARTICLES]),
-        created_at=datetime.now(tz=timezone.utc),
+        created_at=utc_now(),
     )

--- a/backend/app/services/ticker_service.py
+++ b/backend/app/services/ticker_service.py
@@ -1,0 +1,74 @@
+"""
+ticker_service.py
+──────────────────
+실제 상장 종목 티커 조회/생성 서비스.
+yfinance 프로필(회사명·거래소·섹터) 조회 후 DB에 upsert하며, 동시 요청 경합 시
+insert 실패를 select 재시도로 흡수한다.
+
+시장 전체를 나타내는 의사(疑似) 티커(예: "MARKET")는 실제 종목이 아니므로
+yfinance 조회가 무의미하다 — 이 경우 article_cache_service.get_or_create_ticker()를
+직접 사용한다.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+from supabase import AsyncClient
+
+logger = logging.getLogger(__name__)
+
+
+async def ensure_ticker(db: AsyncClient, symbol: str) -> dict[str, Any]:
+    """실제 종목 티커를 조회하고, 없으면 yfinance 프로필과 함께 생성한다."""
+    normalized = symbol.upper().strip()
+    existing = (
+        await db.table("tickers")
+        .select("*")
+        .eq("symbol", normalized)
+        .limit(1)
+        .execute()
+    )
+    if existing.data:
+        return existing.data[0]
+
+    profile = await asyncio.to_thread(_lookup_ticker_profile, normalized)
+    payload = {
+        "symbol": normalized,
+        "name": profile.get("name") or normalized,
+        "exchange": profile.get("exchange"),
+        "sector": profile.get("sector"),
+    }
+    try:
+        inserted = await db.table("tickers").insert(payload).execute()
+        if inserted.data:
+            return inserted.data[0]
+    except Exception:
+        logger.info("Ticker insert raced or failed; retrying select: %s", normalized)
+
+    retry = (
+        await db.table("tickers")
+        .select("*")
+        .eq("symbol", normalized)
+        .limit(1)
+        .execute()
+    )
+    if retry.data:
+        return retry.data[0]
+    raise RuntimeError(f"Unable to create ticker row for {normalized}")
+
+
+def _lookup_ticker_profile(symbol: str) -> dict[str, Any]:
+    try:
+        import yfinance as yf  # type: ignore
+
+        info = yf.Ticker(symbol).info or {}
+        return {
+            "name": info.get("longName") or info.get("shortName"),
+            "exchange": info.get("exchange"),
+            "sector": info.get("sector"),
+        }
+    except Exception:
+        return {"name": symbol, "exchange": None, "sector": None}

--- a/backend/app/time_utils.py
+++ b/backend/app/time_utils.py
@@ -1,0 +1,16 @@
+"""
+time_utils.py
+─────────────
+UTC 시각 헬퍼. 뉴스/캐시 서비스와 심층 리서치 파이프라인이 공통으로 사용한다.
+"""
+
+from datetime import datetime, timezone
+
+
+def utc_now() -> datetime:
+    """microsecond를 0으로 고정한 현재 UTC 시각."""
+    return datetime.now(timezone.utc).replace(microsecond=0)
+
+
+def utc_now_iso() -> str:
+    return utc_now().isoformat()


### PR DESCRIPTION
Closes #40

## 변경 내용

### 1. LLM 클라이언트 통합
Gemini 호출 경로가 두 벌이었음(`summarization_service`의 직접 `genai.Client` 호출 vs `research_pipeline/llm.py`의 `GeminiClient`). 후자를 `app/llm.py`로 승격해 일원화하고, summarization_service가 이를 사용하도록 변경. 자체 `_parse_llm_response`(````json` 펜스만 처리) 대신 더 견고한 `parse_json_response`(정규식 fallback 포함)로 통일.

### 2. 티커 조회/생성 로직 통합
`app/services/ticker_service.py` 신설 — `research_cache_service.ensure_ticker()`(경합 재시도 + yfinance 프로필 조회)를 이관. `news_router`가 이를 사용하도록 변경해 뉴스 쪽 티커 생성 시에도 exchange/sector가 채워지고, 블로킹 호출이던 `news_service.get_company_name()`도 제거됨. `article_cache_service.get_or_create_ticker`는 `"MARKET"` 의사 티커 전용으로 범위를 명확히 함(실제 종목이 아니라 yfinance 조회가 무의미하므로 통합하지 않음).

### 3. Supabase 클라이언트 생성 공통화
`dependencies.py`에 `create_db_client()` 헬퍼 추출 — `get_db()`와 `research_router.run_research_job()`(BackgroundTasks라 Depends 불가)이 공유.

### 4. UTC 시각 헬퍼 통일
`app/time_utils.py` 신설(`utc_now`/`utc_now_iso`) — 산재해 있던 `datetime.now(timezone.utc)` 호출과 `research_cache_service.utc_now()`, `research_pipeline/utils.utc_now_iso()` 중복 정의를 통일.

### 5. financials.py 중복 제거
구현이 동일했던 `_usd_m()`/`_shares_m()`(둘 다 ÷1,000,000)을 `_to_millions()` 하나로 통합.

## 검증
- 전체 backend 파일 syntax check 통과
- 제거/이동된 심볼(`research_pipeline.llm`, `get_company_name`, `research_cache_service.ensure_ticker`, `_usd_m`, `_shares_m`, `datetime.now(timezone.utc)`) grep 재확인 — 잔여 참조 없음
- 로컬에 Python 의존성이 설치되어 있지 않아 실제 `uvicorn` 기동 테스트는 수행하지 못함 — 배포 전 스테이징에서 `/health`, `/v1/news/{symbol}`, `/v1/research/{symbol}` 동작 확인 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)