### PR TITLE
refactor: model_config 로더 패턴 통일 (@lru_cache) (#42)

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -53,16 +53,11 @@ class FeatureModelConfig:
     max_tokens: int
 
 
-_model_config: dict | None = None
-
-
+@lru_cache
 def _load_model_config() -> dict:
-    global _model_config
-    if _model_config is None:
-        config_path = Path(__file__).parent / "model_config.yaml"
-        with open(config_path) as f:
-            _model_config = yaml.safe_load(f)
-    return _model_config
+    config_path = Path(__file__).parent / "model_config.yaml"
+    with open(config_path) as f:
+        return yaml.safe_load(f)
 
 
 def get_feature_config(feature: str) -> FeatureModelConfig:


### PR DESCRIPTION
Closes #42

## 변경 내용
`app/config.py`의 `_load_model_config()`가 수동 전역 캐시(`global _model_config`)를 쓰고 있었는데, `app/research_pipeline/research_config.py`의 `load_model_config()`는 이미 `@lru_cache`를 쓰고 있었다. 스키마가 달라(`features/defaults` vs `defaults/sections`) 파일 자체는 분리 유지가 맞지만, 로딩 패턴을 `@lru_cache`로 통일해 `global` 문을 제거했다.

## 검증
- syntax check 통과
- `_model_config` 전역 변수·`global` 문 잔여 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)