### PR TITLE
fix: Settings extra_forbidden 에러 해결

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -38,6 +38,7 @@ class Settings(BaseSettings):
     class Config:
         env_file = ".env"
         env_file_encoding = "utf-8"
+        extra = "ignore"
 
 
 @lru_cache


### PR DESCRIPTION
## Summary
- `backend/app/config.py`의 `Settings.Config`에 `extra = "ignore"`를 추가해, 로컬 `.env`에 모델에 정의되지 않은 필드(예: 이전에 제거된 `SUPABASE_ANON_KEY`)가 남아있어도 `pydantic.ValidationError`로 백엔드 기동이 실패하지 않도록 함.

## Test plan
- [x] `python -c "from app.config import get_settings; get_settings()"` — 정상 로드 확인
- [x] `uvicorn app.main:app` 로컬 기동 후 `/docs` 200 OK 확인

Fixes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)